### PR TITLE
#20 - Opt out of system dark mode to fix issues where using the defau…

### DIFF
--- a/Beam/Info.plist
+++ b/Beam/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>UIUserInterfaceStyle</key>
+	<string>Light</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>


### PR DESCRIPTION
…lt theme caused some screens to appear dark

## Some areas of the UI are no longer dark when the OS is in dark mode while beam is using the default theme.

Since Beam implements its own dark mode system, we need to opt-out of the system-wide dark mode feature introduced in iOS 13.

<img src="https://user-images.githubusercontent.com/656538/68978869-ffd21380-07c9-11ea-8105-f2cd6927796c.PNG" height="500">

## Settings
<img src="https://user-images.githubusercontent.com/656538/68978868-ffd21380-07c9-11ea-844b-b36b1e7a7399.PNG" height="500">