### PR TITLE
Fix crash when displaying content with link

### DIFF
--- a/Beam/Extensions/TTTAttributedLabel+Links.swift
+++ b/Beam/Extensions/TTTAttributedLabel+Links.swift
@@ -11,7 +11,8 @@ import TTTAttributedLabel
 extension TTTAttributedLabel {
     
     class fileprivate func baseBeamLinkAttributes() -> [NSAttributedString.Key: Any] {
-        return [NSAttributedString.Key.underlineStyle: []]
+        let underlineStyle: NSUnderlineStyle = []
+        return [.underlineStyle: NSNumber(value: underlineStyle.rawValue)]
     }
     
     class func beamLinkAttributesForMode(_ mode: DisplayMode) -> [NSAttributedString.Key: Any] {


### PR DESCRIPTION
Although UIKit expects the underlinestyle attribute to have a value of type NSNumber, it was set to an empty array here. This bug lead to CoreText crashes inside TTTAttributedLabel for some text content.

fixes #32 