### PR TITLE
Remove UIViewControllerPreviewing

### DIFF
--- a/Beam/UI/Messages/MessagesViewController.swift
+++ b/Beam/UI/Messages/MessagesViewController.swift
@@ -150,8 +150,6 @@ class MessagesViewController: BeamTableViewController, BeamViewControllerLoading
         self.refreshControl!.addTarget(self, action: #selector(MessagesViewController.refresh(_:)), for: .valueChanged)
         
         self.viewType = MessagesViewType.messages
-    
-        self.registerForPreviewing(with: self, sourceView: self.tableView)
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -427,32 +425,5 @@ extension MessagesViewController {
             self.tableView.tableFooterView = self.loadingFooterView
             self.loadingFooterView.startAnimating()
         }
-    }
-}
-
-@available(iOS 9, *)
-extension MessagesViewController: UIViewControllerPreviewingDelegate {
-    
-    func previewingContext(_ previewingContext: UIViewControllerPreviewing, viewControllerForLocation location: CGPoint) -> UIViewController? {
-        if let indexPath = self.tableView.indexPathForRow(at: location),
-            let cell = self.tableView.cellForRow(at: indexPath),
-            let messageConverstation = self.storyboard?.instantiateViewController(withIdentifier: "messageConversation") as? MessageConversationViewController,
-            let message = self.content?[indexPath.row] as? Message,
-            self.viewType == .messages || self.viewType == .sent {
-            
-                //Make viewcontroller
-                messageConverstation.message = message
-            
-                //Set the frame to animate the peek from
-                previewingContext.sourceRect = cell.frame
-            
-                //Pass the view controller to display
-                return messageConverstation
-        }
-        return nil
-    }
-    
-    func previewingContext(_ previewingContext: UIViewControllerPreviewing, commit viewControllerToCommit: UIViewController) {
-        self.show(viewControllerToCommit, sender: previewingContext)
     }
 }

--- a/Beam/UI/Search/MainSearchViewController.swift
+++ b/Beam/UI/Search/MainSearchViewController.swift
@@ -69,8 +69,6 @@ class MainSearchViewController: BeamTableViewController {
         tapGestureRecognizer.cancelsTouchesInView = false
         self.tableView.addGestureRecognizer(tapGestureRecognizer)
         
-        self.registerForPreviewing(with: self, sourceView: self.tableView)
-        
         if self.isModallyPresentedRootViewController() && self.tabBarController == nil {
             self.navigationItem.leftBarButtonItem = UIBarButtonItem(image: UIImage(named: "navigationbar_close"), style: UIBarButtonItem.Style.plain, target: self, action: #selector(MainSearchViewController.cancelTapped(_:)))
         }
@@ -472,39 +470,5 @@ extension MainSearchViewController: UIGestureRecognizerDelegate {
     
     func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool {
         return touch.view == self.tableView
-    }
-}
-
-@available(iOS 9, *)
-extension MainSearchViewController: UIViewControllerPreviewingDelegate {
-    
-    func previewingContext(_ previewingContext: UIViewControllerPreviewing, viewControllerForLocation location: CGPoint) -> UIViewController? {
-        guard let indexPath = self.tableView.indexPathForRow(at: location),
-        let cell = self.tableView.cellForRow(at: indexPath) else {
-            return nil
-        }
-        guard self.searchDisplayMode == MainSearchDisplayMode.recentVisited else {
-            return nil
-        }
-        
-        let subreddit = RedditActivityController.recentlyVisitedSubreddits[indexPath.row]
-        //Open the subreddit
-        let storyboard = UIStoryboard(name: "Subreddit", bundle: nil)
-        if let tabBarController = storyboard.instantiateInitialViewController() as? SubredditTabBarController {
-            tabBarController.subreddit = subreddit
-            
-            //Set the frame to animate the peek from
-            previewingContext.sourceRect = cell.frame
-            
-            return tabBarController
-        }
-
-        return nil
-    
-    }
-    
-    func previewingContext(_ previewingContext: UIViewControllerPreviewing, commit viewControllerToCommit: UIViewController) {
-        //We only show subreddit view controller in this view, which is always presented modally
-        self.present(viewControllerToCommit, animated: true, completion: nil)
     }
 }

--- a/Beam/UI/Search/SubredditListViewController.swift
+++ b/Beam/UI/Search/SubredditListViewController.swift
@@ -49,12 +49,6 @@ class SubredditListViewController: BeamTableViewController, BeamViewControllerLo
         return numberFormatter
     }()
     
-    override func viewDidLoad() {
-        super.viewDidLoad()
-        
-        self.registerForPreviewing(with: self, sourceView: self.tableView)
-    }
-
 }
 
 // MARK: - UITableViewDataSource
@@ -116,37 +110,4 @@ extension SubredditListViewController {
         
     }
     
-}
-
-@available(iOS 9, *)
-extension SubredditListViewController: UIViewControllerPreviewingDelegate {
-    
-    func previewingContext(_ previewingContext: UIViewControllerPreviewing, viewControllerForLocation location: CGPoint) -> UIViewController? {
-        //Cell selection
-        guard let indexPath = self.tableView.indexPathForRow(at: location), let cell = self.tableView.cellForRow(at: indexPath) else {
-            return nil
-        }
-        guard let subreddit = self.content?[indexPath.row] else {
-            return nil
-        }
-        
-        //Make the subreddit previewing view controller
-        let storyboard = UIStoryboard(name: "Subreddit", bundle: nil)
-        if let tabBarController = storyboard.instantiateInitialViewController() as? SubredditTabBarController {
-            
-            tabBarController.subreddit = subreddit
-            
-            //Set the frame to animate the peek from
-            previewingContext.sourceRect = cell.frame
-            
-            //Pass the view controller to display
-            return tabBarController
-        }
-        return nil
-    }
-    
-    func previewingContext(_ previewingContext: UIViewControllerPreviewing, commit viewControllerToCommit: UIViewController) {
-        //We only show subreddit view controller in this view, which is always presented modally
-        self.present(viewControllerToCommit, animated: true, completion: nil)
-    }
 }

--- a/Beam/UI/Search/SubredditsSearchViewController.swift
+++ b/Beam/UI/Search/SubredditsSearchViewController.swift
@@ -76,13 +76,6 @@ class SubredditsSearchViewController: BeamTableViewController, UISearchResultsUp
         }
     }
     
-    override func viewDidLoad() {
-        super.viewDidLoad()
-        
-        self.registerForPreviewing(with: self, sourceView: self.tableView)
-        
-    }
-    
     func searchBar(_ searchBar: UISearchBar, selectedScopeButtonIndexDidChange selectedScope: Int) {
         let isLocal = (selectedScope == 0)
         if isLocal != self.localSearch {
@@ -196,36 +189,4 @@ class SubredditsSearchViewController: BeamTableViewController, UISearchResultsUp
         }
     }
     
-}
-
-@available(iOS 9, *)
-extension SubredditsSearchViewController: UIViewControllerPreviewingDelegate {
-    
-    func previewingContext(_ previewingContext: UIViewControllerPreviewing, viewControllerForLocation location: CGPoint) -> UIViewController? {
-        guard let indexPath = self.tableView.indexPathForRow(at: location), let cell = self.tableView.cellForRow(at: indexPath) else {
-            return nil
-        }
-        guard let subreddit = self.objects?[indexPath.row] else {
-            return nil
-        }
-        
-        //Open the subreddit
-        let storyboard = UIStoryboard(name: "Subreddit", bundle: nil)
-        if let tabBarController = storyboard.instantiateInitialViewController() as? SubredditTabBarController {
-            tabBarController.subreddit = subreddit
-            
-            //Set the frame to animate the peek from
-            previewingContext.sourceRect = cell.frame
-            
-            //Pass the view controller to display
-            return tabBarController
-        }
-        
-        return nil
-    }
-    
-    func previewingContext(_ previewingContext: UIViewControllerPreviewing, commit viewControllerToCommit: UIViewController) {
-        //We only show subreddit view controller in this view, which is always presented modally
-        self.present(viewControllerToCommit, animated: true, completion: nil)
-    }
 }

--- a/Beam/UI/Settings/Imgur Manager/ImgurGalleryAlbumContentViewController.swift
+++ b/Beam/UI/Settings/Imgur Manager/ImgurGalleryAlbumContentViewController.swift
@@ -57,12 +57,6 @@ class ImgurGalleryAlbumContentViewController: UIViewController, AWKGalleryItemCo
         self.collectionView.contentInset = UIEdgeInsets(top: self.view.safeAreaInsets.top + 44, left: CGFloat(0), bottom: self.galleryViewController?.galleryBottomLayoutGuide.length ?? 0.0, right: CGFloat(0))
     }
     
-    override func viewDidLoad() {
-        super.viewDidLoad()
-        
-        self.registerForPreviewing(with: self, sourceView: self.collectionView)
-    }
-    
     override func updateViewConstraints() {
         self.configureCollectionViewSize()
         super.updateViewConstraints()
@@ -207,38 +201,4 @@ extension ImgurGalleryAlbumContentViewController: AWKGalleryDelegate {
         
     }
     
-}
-
-@available(iOS 9, *)
-extension ImgurGalleryAlbumContentViewController: UIViewControllerPreviewingDelegate {
-    
-    func previewingContext(_ previewingContext: UIViewControllerPreviewing, viewControllerForLocation location: CGPoint) -> UIViewController? {
-        if let indexPath = self.collectionView.indexPathForItem(at: location),
-            let cell = self.collectionView.cellForItem(at: indexPath),
-            let image = self.album?.images?[(indexPath as IndexPath).item] {
-            
-            var viewController: UIViewController?
-            if cell is PostImageCollectionPartItemCell {
-                
-                let galleryViewController = self.galleryViewControllerForImage(image)
-                galleryViewController.shouldAutomaticallyDisplaySecondaryViews = false
-                viewController = galleryViewController
-                viewController?.preferredContentSize = image.viewControllerPreviewingSize()
-            }
-            
-            //Set the frame to animate the peek from
-            previewingContext.sourceRect = cell.frame
-            
-            //Pass the view controller to display
-            return viewController
-        }
-        return nil
-    }
-    
-    func previewingContext(_ previewingContext: UIViewControllerPreviewing, commit viewControllerToCommit: UIViewController) {
-        if let galleryViewController = viewControllerToCommit as? AWKGalleryViewController {
-            galleryViewController.shouldAutomaticallyDisplaySecondaryViews = true
-            self.presentGalleryViewController(galleryViewController, sourceView: nil)
-        }
-    }
 }

--- a/Beam/UI/Subreddits/Media Overview/GalleryAlbumContentViewController.swift
+++ b/Beam/UI/Subreddits/Media Overview/GalleryAlbumContentViewController.swift
@@ -64,12 +64,6 @@ class GalleryAlbumContentViewController: UIViewController, AWKGalleryItemContent
         
         self.collectionView.contentInset = UIEdgeInsets(top: 44, left: CGFloat(0), bottom: self.galleryViewController?.galleryBottomLayoutGuide.length ?? 0.0, right: CGFloat(0))
     }
-    
-    override func viewDidLoad() {
-        super.viewDidLoad()
-        
-        self.registerForPreviewing(with: self, sourceView: self.collectionView)
-    }
 
     override func updateViewConstraints() {
         self.configureCollectionViewSize()
@@ -225,38 +219,4 @@ extension GalleryAlbumContentViewController: AWKGalleryDelegate {
         
     }
     
-}
-
-@available(iOS 9, *)
-extension GalleryAlbumContentViewController: UIViewControllerPreviewingDelegate {
-    
-    func previewingContext(_ previewingContext: UIViewControllerPreviewing, viewControllerForLocation location: CGPoint) -> UIViewController? {
-        if let indexPath = self.collectionView.indexPathForItem(at: location),
-            let cell = self.collectionView.cellForItem(at: indexPath),
-            let mediaObject = self.mediaCollectionController?.itemAtIndexPath(indexPath) {
-                
-                var viewController: UIViewController?
-                if cell is PostImageCollectionPartItemCell {
-                    
-                    let galleryViewController = self.galleryViewControllerForMediaItem(mediaObject)
-                    galleryViewController.shouldAutomaticallyDisplaySecondaryViews = false
-                    viewController = galleryViewController
-                    viewController?.preferredContentSize = mediaObject.viewControllerPreviewingSize()
-                }
-                
-                //Set the frame to animate the peek from
-                previewingContext.sourceRect = cell.frame
-                
-                //Pass the view controller to display
-                return viewController
-        }
-        return nil
-    }
-    
-    func previewingContext(_ previewingContext: UIViewControllerPreviewing, commit viewControllerToCommit: UIViewController) {
-        if let galleryViewController = viewControllerToCommit as? AWKGalleryViewController {
-            galleryViewController.shouldAutomaticallyDisplaySecondaryViews = true
-            self.presentGalleryViewController(galleryViewController, sourceView: nil)
-        }
-    }
 }

--- a/Beam/UI/Subreddits/Media Overview/PostMediaOverviewViewController.swift
+++ b/Beam/UI/Subreddits/Media Overview/PostMediaOverviewViewController.swift
@@ -52,11 +52,6 @@ class PostMediaOverviewViewController: BeamCollectionViewController, PostMetadat
         super.viewDidLoad()
 
         reloadCollectionViewLayoutAnimated(false)
-        
-        if let collectioNView = self.collectionView {
-            self.registerForPreviewing(with: self, sourceView: collectioNView)
-        }
-        
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -252,39 +247,4 @@ extension PostMediaOverviewViewController: AWKGalleryDelegate {
         
     }
     
-}
-
-@available(iOS 9, *)
-extension PostMediaOverviewViewController: UIViewControllerPreviewingDelegate {
-    
-    func previewingContext(_ previewingContext: UIViewControllerPreviewing, viewControllerForLocation location: CGPoint) -> UIViewController? {
-        if let indexPath = self.collectionView?.indexPathForItem(at: location),
-            let cell = self.collectionView?.cellForItem(at: indexPath),
-            let mediaObject = self.mediaCollectionController.itemAtIndexPath(indexPath),
-            let post = self.post {
-                
-                var viewController: UIViewController?
-                if cell is MediaOverviewCollectionViewCell {
-                    
-                    let galleryViewController = self.galleryViewControllerForPost(post, mediaItem: mediaObject)
-                    galleryViewController.shouldAutomaticallyDisplaySecondaryViews = false
-                    viewController = galleryViewController
-                    viewController?.preferredContentSize = mediaObject.viewControllerPreviewingSize()
-                }
-                
-                //Set the frame to animate the peek from
-                previewingContext.sourceRect = cell.frame
-                
-                //Pass the view controller to display
-                return viewController
-        }
-        return nil
-    }
-    
-    func previewingContext(_ previewingContext: UIViewControllerPreviewing, commit viewControllerToCommit: UIViewController) {
-        if let galleryViewController = viewControllerToCommit as? AWKGalleryViewController {
-            galleryViewController.shouldAutomaticallyDisplaySecondaryViews = true
-            self.presentGalleryViewController(galleryViewController, sourceView: nil)
-        }
-    }
 }

--- a/Beam/UI/Subreddits/Media Overview/SubredditMediaOverviewViewController.swift
+++ b/Beam/UI/Subreddits/Media Overview/SubredditMediaOverviewViewController.swift
@@ -139,8 +139,6 @@ class SubredditMediaOverviewViewController: BeamViewController, SubredditTabItem
         let insets = UIEdgeInsets(top: self.toolbar.frame.height, left: 0, bottom: 0, right: 0)
         self.collectionView?.contentInset = insets
         self.collectionView?.scrollIndicatorInsets = insets
-        
-        self.registerForPreviewing(with: self, sourceView: self.collectionView)
     }
     
     deinit {
@@ -738,45 +736,5 @@ extension SubredditMediaOverviewViewController: NavigationBarNotificationDisplay
     
     func topViewForDisplayOfnotificationView<NotificationView: UIView>(_ view: NotificationView) -> UIView? where NotificationView: NavigationBarNotification {
         return self.sortingBar.superview
-    }
-}
-
-@available(iOS 9, *)
-extension SubredditMediaOverviewViewController: UIViewControllerPreviewingDelegate {
-    
-    func previewingContext(_ previewingContext: UIViewControllerPreviewing, viewControllerForLocation location: CGPoint) -> UIViewController? {
-        if let indexPath = self.collectionView.indexPathForItem(at: location),
-            let cell = self.collectionView.cellForItem(at: indexPath),
-            let post = self.mediaCollectionController?.itemAtIndexPath(indexPath),
-            let mediaObject = post.mediaObjects?.firstObject as? Snoo.MediaObject {
-                
-                var viewController: UIViewController?
-                if cell is MediaOverviewCollectionViewCell {
-                    
-                    let galleryViewController = self.galleryViewControllerForPost(post, mediaItem: mediaObject)
-                    self.galleryViewController = galleryViewController
-                    galleryViewController.shouldAutomaticallyDisplaySecondaryViews = false
-                    viewController = galleryViewController
-                    if let mediaObjects = post.mediaObjects, mediaObjects.count > 1 {
-                        viewController?.preferredContentSize = UIScreen.main.bounds.size
-                    } else {
-                        viewController?.preferredContentSize = mediaObject.viewControllerPreviewingSize()
-                    }
-                }
-                
-                //Set the frame to animate the peek from
-                previewingContext.sourceRect = cell.frame
-                
-                //Pass the view controller to display
-                return viewController
-        }
-        return nil
-    }
-    
-    func previewingContext(_ previewingContext: UIViewControllerPreviewing, commit viewControllerToCommit: UIViewController) {
-        if let galleryViewController = viewControllerToCommit as? AWKGalleryViewController {
-            galleryViewController.shouldAutomaticallyDisplaySecondaryViews = true
-            self.presentGalleryViewController(galleryViewController, sourceView: nil)
-        }
     }
 }

--- a/Beam/UI/Subreddits/Subreddit View/AddToMultiredditViewController.swift
+++ b/Beam/UI/Subreddits/Subreddit View/AddToMultiredditViewController.swift
@@ -74,8 +74,6 @@ class AddToMultiredditViewController: BeamTableViewController, BeamViewControlle
         NotificationCenter.default.addObserver(self, selector: #selector(AddToMultiredditViewController.authenticatedUserDidChange(_:)), name: AuthenticationController.UserDidChangeNotificationName, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(AddToMultiredditViewController.expiredContentDeleted(_:)), name: .DataControllerExpiredContentDeletedFromContext, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(AddToMultiredditViewController.multiredditDidUpdate(_:)), name: MultiredditDidUpdateNotificationName, object: nil)
-        
-        self.registerForPreviewing(with: self, sourceView: self.tableView)
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -207,37 +205,4 @@ extension AddToMultiredditViewController: CollectionControllerDelegate {
         
     }
     
-}
-
-@available(iOS 9, *)
-extension AddToMultiredditViewController: UIViewControllerPreviewingDelegate {
-    
-    func previewingContext(_ previewingContext: UIViewControllerPreviewing, viewControllerForLocation location: CGPoint) -> UIViewController? {
-        guard let indexPath = self.tableView.indexPathForRow(at: location), let cell = self.tableView.cellForRow(at: indexPath) else {
-            return nil
-        }
-        guard let multireddit = self.content?[indexPath.row] else {
-            return nil
-        }
-        
-        //Open the subreddit
-        let storyboard = UIStoryboard(name: "Subreddit", bundle: nil)
-        if let tabBarController = storyboard.instantiateInitialViewController() as? SubredditTabBarController {
-            tabBarController.subreddit = multireddit
-            
-            //Set the frame to animate the peek from
-            previewingContext.sourceRect = cell.frame
-            
-            //Pass the view controller to display
-            return tabBarController
-        }
-        
-        return nil
-        
-    }
-    
-    func previewingContext(_ previewingContext: UIViewControllerPreviewing, commit viewControllerToCommit: UIViewController) {
-        //We only show subreddit view controller in this view, which is always presented modally
-        self.present(viewControllerToCommit, animated: true, completion: nil)
-    }
 }

--- a/Beam/UI/Subreddits/Subreddit View/Edit Multireddit/MultiredditSubsViewController.swift
+++ b/Beam/UI/Subreddits/Subreddit View/Edit Multireddit/MultiredditSubsViewController.swift
@@ -64,8 +64,6 @@ class MultiredditSubsViewController: BeamTableViewController, NSFetchedResultsCo
         NotificationCenter.default.addObserver(self, selector: #selector(MultiredditSubsViewController.userDidUpdate(_:)), name: AuthenticationController.UserDidUpdateNotificationName, object: AppDelegate.shared.authenticationController)
         
         configureData()
-        
-        self.registerForPreviewing(with: self, sourceView: self.tableView)
     }
     
     @objc fileprivate func userDidUpdate(_ notification: Notification?) {
@@ -377,46 +375,4 @@ class MultiredditSubsViewController: BeamTableViewController, NSFetchedResultsCo
         }
     }
     
-}
-
-extension MultiredditSubsViewController: UIViewControllerPreviewingDelegate {
-    
-    func previewingContext(_ previewingContext: UIViewControllerPreviewing, viewControllerForLocation location: CGPoint) -> UIViewController? {
-        //Cell selection
-        guard let indexPath = self.tableView.indexPathForRow(at: location), let cell = self.tableView.cellForRow(at: indexPath) else {
-            return nil
-        }
-        
-        var subreddit: Subreddit?
-        if self.hasSubredditsSection && (indexPath as IndexPath).section == 0 {
-            subreddit = self.subreddits?[indexPath.row]
-        } else {
-            subreddit = self.suggestions?[indexPath.row]
-        }
-        
-        guard subreddit != nil else {
-            return nil
-        }
-        
-        //Make the subreddit previewing view controller
-        let storyboard = UIStoryboard(name: "Subreddit", bundle: nil)
-        if let tabBarController = storyboard.instantiateInitialViewController() as? SubredditTabBarController {
-            
-            tabBarController.subreddit = subreddit
-            
-            //Set the frame to animate the peek from
-            previewingContext.sourceRect = cell.frame
-            
-            //Pass the view controller to display
-            return tabBarController
-        }
-
-        return nil
-        
-    }
-    
-    func previewingContext(_ previewingContext: UIViewControllerPreviewing, commit viewControllerToCommit: UIViewController) {
-        //We only show subreddit view controller in this view, which is always presented modally
-        self.present(viewControllerToCommit, animated: true, completion: nil)
-    }
 }

--- a/Beam/UI/Subscriptions/MultiredditsViewController.swift
+++ b/Beam/UI/Subscriptions/MultiredditsViewController.swift
@@ -71,8 +71,6 @@ final class MultiredditsViewController: BeamTableViewController, NSFetchedResult
         NotificationCenter.default.addObserver(self, selector: #selector(MultiredditsViewController.expiredContentDeleted(_:)), name: .DataControllerExpiredContentDeletedFromContext, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(MultiredditsViewController.multiredditDidUpdate(_:)), name: MultiredditDidUpdateNotificationName, object: nil)
         
-        self.registerForPreviewing(with: self, sourceView: self.tableView)
-        
         //Add refresh control
         let refreshControl = UIRefreshControl()
         refreshControl.addTarget(self, action: #selector(refreshContent(sender:)), for: .valueChanged)
@@ -215,36 +213,4 @@ extension MultiredditsViewController: CollectionControllerDelegate {
         
     }
     
-}
-
-@available(iOS 9, *)
-extension MultiredditsViewController: UIViewControllerPreviewingDelegate {
-    
-    func previewingContext(_ previewingContext: UIViewControllerPreviewing, viewControllerForLocation location: CGPoint) -> UIViewController? {
-        guard let indexPath = self.tableView.indexPathForRow(at: location), let cell = self.tableView.cellForRow(at: indexPath) else {
-            return nil
-        }
-        guard let multireddit = self.content?[indexPath.row] else {
-            return nil
-        }
-        
-        //Open the subreddit
-        let storyboard = UIStoryboard(name: "Subreddit", bundle: nil)
-        if let tabBarController = storyboard.instantiateInitialViewController() as? SubredditTabBarController {
-            tabBarController.subreddit = multireddit
-            
-            //Set the frame to animate the peek from
-            previewingContext.sourceRect = cell.frame
-            
-            //Pass the view controller to display
-            return tabBarController
-        }
-        
-        return nil
-    }
-    
-    func previewingContext(_ previewingContext: UIViewControllerPreviewing, commit viewControllerToCommit: UIViewController) {
-        //We only show subreddit view controller in this view, which is always presented modally
-        self.present(viewControllerToCommit, animated: true, completion: nil)
-    }
 }

--- a/Beam/UI/Subscriptions/SubredditsViewController.swift
+++ b/Beam/UI/Subscriptions/SubredditsViewController.swift
@@ -260,8 +260,6 @@ final class SubredditsViewController: BeamTableViewController, BeamViewControlle
     
         self.updateTitle()
         
-        self.registerForPreviewing(with: self, sourceView: self.tableView)
-        
         //Add a refresh control
         let refreshControl = UIRefreshControl()
         refreshControl.addTarget(self, action: #selector(refreshContent(sender:)), for: .valueChanged)
@@ -833,36 +831,4 @@ extension SubredditsViewController: CollectionControllerDelegate {
         }
     }
     
-}
-
-@available(iOS 9, *)
-extension SubredditsViewController: UIViewControllerPreviewingDelegate {
-    
-    func previewingContext(_ previewingContext: UIViewControllerPreviewing, viewControllerForLocation location: CGPoint) -> UIViewController? {
-        guard let indexPath = self.tableView.indexPathForRow(at: location), let cell = self.tableView.cellForRow(at: indexPath) else {
-            return nil
-        }
-        guard let subreddit = self.content?[(indexPath as IndexPath).section].subreddits[indexPath.row] else {
-            return nil
-        }
-        
-        //Make the subreddit view controller
-        let storyboard = UIStoryboard(name: "Subreddit", bundle: nil)
-        if let tabBarController = storyboard.instantiateInitialViewController() as? SubredditTabBarController {
-                
-                tabBarController.subreddit = subreddit
-                
-                //Set the frame to animate the peek from
-                previewingContext.sourceRect = cell.frame
-                
-                //Pass the view controller to display
-                return tabBarController
-        }
-        return nil
-    }
-    
-    func previewingContext(_ previewingContext: UIViewControllerPreviewing, commit viewControllerToCommit: UIViewController) {
-        //We only show subreddit view controller in this view, which is always presented modally
-        self.present(viewControllerToCommit, animated: true, completion: nil)
-    }
 }


### PR DESCRIPTION
Since iOS 13 deprecates `UIViewControllerPreviewingDelegate` and it's not being used anymore, we can remove this. If we want, we could implement `UIContextMenuInteraction` at a later point of time.