### PR TITLE
Remove authentication request timeout interval

### DIFF
--- a/Beam.xcodeproj/project.pbxproj
+++ b/Beam.xcodeproj/project.pbxproj
@@ -4307,6 +4307,7 @@
 				CODE_SIGN_ENTITLEMENTS = beam/beam.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CURRENT_PROJECT_VERSION = 390;
 				DEFINES_MODULE = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -4348,6 +4349,7 @@
 				CODE_SIGN_ENTITLEMENTS = beam/beam.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CURRENT_PROJECT_VERSION = 390;
 				DEFINES_MODULE = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",

--- a/Beam/Info.plist
+++ b/Beam/Info.plist
@@ -94,7 +94,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>389</string>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSApplicationQueriesSchemes</key>

--- a/Snoo/Authentication/AuthenticationController.swift
+++ b/Snoo/Authentication/AuthenticationController.swift
@@ -241,12 +241,7 @@ public final class AuthenticationController: NSObject {
      */
     public lazy var basicURLSessionConfiguration: URLSessionConfiguration = {
         let configuration = URLSessionConfiguration.default
-        
-        configuration.timeoutIntervalForRequest = 10
-        configuration.timeoutIntervalForResource = 20
-        
-        let bundleIdentifier = Bundle.main.bundleIdentifier!
-        
+        let bundleIdentifier = Bundle.main.bundleIdentifier ?? ""
         var headers = [String: String]()
         headers["Accept"] = "application/json"
         headers["User-Agent"] = "ios:\(bundleIdentifier):v\(self.configuration.clientVersion) (by /u/beamreddit)"


### PR DESCRIPTION
Original request: https://www.reddit.com/r/beamreddit/comments/evgp39/latest_beta/

This change removes the custom timeout interval we use on URLSessionConfiguration from AuthenticationController. I'm not sure why we would want different behavior from iOS defaults after all.