### PR TITLE
BeamControl dark mode adjustments

### DIFF
--- a/Beam/UI/Generic UI/Base Classes/Views/BeamControl.swift
+++ b/Beam/UI/Generic UI/Base Classes/Views/BeamControl.swift
@@ -15,6 +15,13 @@ class BeamControl: UIControl, BeamAppearance {
         self.appearanceDidChange()
     }
     
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        if traitCollection.userInterfaceStyle != previousTraitCollection?.userInterfaceStyle {
+            appearanceDidChange()
+        }
+    }
+    
     func appearanceDidChange() {
         switch self.userInterfaceStyle {
         case .dark:


### PR DESCRIPTION
The BeamControl class didn't adjust its appearance on traitcollection changes. Adding this fixes #42 