### PR TITLE
Fix crash on switching accounts

### DIFF
--- a/Snoo/UserActivityController.swift
+++ b/Snoo/UserActivityController.swift
@@ -47,6 +47,8 @@ public final class UserActivityController: NSObject {
     }
     
     fileprivate func flushVisits() {
+        assert(Thread.isMainThread)
+        
         guard self.authenticationController?.isAuthenticated == true else {
             return
         }


### PR DESCRIPTION
When switching accounts, we accessed the main (view) Core Data context from a background thread. I've tidied up the appropriate method a little bit with some extra explanation and added an async to fix.

I'm not really happy with this fix, but I guess this is the best we could do for now without refactoring the authentication and Core Data stack.